### PR TITLE
メッセージのためのAPIとフロント修正

### DIFF
--- a/app/Http/Controllers/Api/MessageController.php
+++ b/app/Http/Controllers/Api/MessageController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\Message\UpdateRequest;
 use App\Http\Resources\MessageResource;
 use App\Models\Message;
 
@@ -13,6 +14,13 @@ class MessageController extends Controller
         $messages = Message::orderBy('id', 'DESC')->with('user', 'likedUsers')->cursorPaginate(10);
 
         return MessageResource::collection($messages);
+    }
+
+    function update(UpdateRequest $request, Message $message)
+    {
+        $message->update($request->validated());
+
+        return MessageResource::make($message);
     }
 
     function destroy(Message $message)

--- a/app/Http/Controllers/Api/MessageController.php
+++ b/app/Http/Controllers/Api/MessageController.php
@@ -3,9 +3,11 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\Message\StoreRequest;
 use App\Http\Requests\Api\Message\UpdateRequest;
 use App\Http\Resources\MessageResource;
 use App\Models\Message;
+use Illuminate\Support\Facades\Auth;
 
 class MessageController extends Controller
 {
@@ -14,6 +16,16 @@ class MessageController extends Controller
         $messages = Message::orderBy('id', 'DESC')->with('user', 'likedUsers')->cursorPaginate(10);
 
         return MessageResource::collection($messages);
+    }
+
+    function store(StoreRequest $request)
+    {
+        $user = Auth::user();
+        $message = $request->makeMessage();
+        $message->user()->associate($user);
+        $message->save();
+
+        return MessageResource::make($message);
     }
 
     function update(UpdateRequest $request, Message $message)

--- a/app/Http/Controllers/Api/MessageController.php
+++ b/app/Http/Controllers/Api/MessageController.php
@@ -14,4 +14,9 @@ class MessageController extends Controller
 
         return MessageResource::collection($messages);
     }
+
+    function destroy(Message $message)
+    {
+        return response()->json($message->delete());
+    }
 }

--- a/app/Http/Requests/Api/Message/StoreRequest.php
+++ b/app/Http/Requests/Api/Message/StoreRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests\Api\Message;
+
+use App\Models\Message;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Validation\ValidationException;
+
+class StoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'content' => 'required|string|max:140',
+        ];
+    }
+
+    public function makeMessage(): Message
+    {
+        return new Message($this->validated());
+    }
+
+    protected function failedValidation(Validator $validator)
+    {
+        $errors = (new ValidationException($validator))->errors();
+        throw new HttpResponseException(response()->json([
+            'message' => 'Failed validation',
+            'errors' => $errors,
+        ], 400));
+    }
+}

--- a/app/Http/Requests/Api/Message/UpdateRequest.php
+++ b/app/Http/Requests/Api/Message/UpdateRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests\Api\Message;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Validation\ValidationException;
+
+class UpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'content' => 'required|string|max:140',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator)
+    {
+        $errors = (new ValidationException($validator))->errors();
+        throw new HttpResponseException(response()->json([
+            'message' => 'Failed validation',
+            'errors' => $errors,
+        ], 400));
+    }
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,6 +1,17 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
+/***/ "./node_modules/@babel/runtime/regenerator/index.js":
+/*!**********************************************************!*\
+  !*** ./node_modules/@babel/runtime/regenerator/index.js ***!
+  \**********************************************************/
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+module.exports = __webpack_require__(/*! regenerator-runtime */ "./node_modules/regenerator-runtime/runtime.js");
+
+
+/***/ }),
+
 /***/ "./node_modules/alpinejs/dist/alpine.js":
 /*!**********************************************!*\
   !*** ./node_modules/alpinejs/dist/alpine.js ***!
@@ -3800,6 +3811,18 @@ module.exports = {
 
 __webpack_require__(/*! ./bootstrap */ "./resources/js/bootstrap.js");
 
+__webpack_require__(/*! ./requests/likes/storeLike */ "./resources/js/requests/likes/storeLike.js");
+
+__webpack_require__(/*! ./requests/likes/destroyLike */ "./resources/js/requests/likes/destroyLike.js");
+
+__webpack_require__(/*! ./requests/messages/fetchMessage */ "./resources/js/requests/messages/fetchMessage.js");
+
+__webpack_require__(/*! ./requests/messages/storeMessage */ "./resources/js/requests/messages/storeMessage.js");
+
+__webpack_require__(/*! ./requests/messages/updateMessage */ "./resources/js/requests/messages/updateMessage.js");
+
+__webpack_require__(/*! ./requests/messages/destroyMessage */ "./resources/js/requests/messages/destroyMessage.js");
+
 __webpack_require__(/*! alpinejs */ "./node_modules/alpinejs/dist/alpine.js");
 
 /***/ }),
@@ -3832,6 +3855,454 @@ window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 //     cluster: process.env.MIX_PUSHER_APP_CLUSTER,
 //     forceTLS: true
 // });
+
+/***/ }),
+
+/***/ "./resources/js/requests/likes/destroyLike.js":
+/*!****************************************************!*\
+  !*** ./resources/js/requests/likes/destroyLike.js ***!
+  \****************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/regenerator */ "./node_modules/@babel/runtime/regenerator/index.js");
+/* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__);
+
+
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+var destroyLike = /*#__PURE__*/function () {
+  var _ref2 = _asyncToGenerator( /*#__PURE__*/_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().mark(function _callee(_ref) {
+    var messageId, onDestroyLike, onDestroyLikeError, response;
+    return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().wrap(function _callee$(_context) {
+      while (1) {
+        switch (_context.prev = _context.next) {
+          case 0:
+            messageId = _ref.messageId, onDestroyLike = _ref.onDestroyLike, onDestroyLikeError = _ref.onDestroyLikeError;
+            _context.next = 3;
+            return fetch('/api/likes', {
+              method: 'delete',
+              headers: {
+                'Content-Type': 'application/json; charset=utf-8'
+              },
+              body: JSON.stringify({
+                message_id: messageId
+              })
+            });
+
+          case 3:
+            response = _context.sent;
+
+            if (response.ok) {
+              onDestroyLike();
+            } else {
+              if (response.status === 400) {
+                onDestroyLikeError();
+              } else {
+                alert('予期せぬエラーが発生しました');
+              }
+            }
+
+          case 5:
+          case "end":
+            return _context.stop();
+        }
+      }
+    }, _callee);
+  }));
+
+  return function destroyLike(_x) {
+    return _ref2.apply(this, arguments);
+  };
+}();
+
+window.destroyLike = destroyLike;
+
+/***/ }),
+
+/***/ "./resources/js/requests/likes/storeLike.js":
+/*!**************************************************!*\
+  !*** ./resources/js/requests/likes/storeLike.js ***!
+  \**************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/regenerator */ "./node_modules/@babel/runtime/regenerator/index.js");
+/* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__);
+
+
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+var storeLike = /*#__PURE__*/function () {
+  var _ref2 = _asyncToGenerator( /*#__PURE__*/_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().mark(function _callee(_ref) {
+    var messageId, onStoreLike, onStoreLikeError, response;
+    return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().wrap(function _callee$(_context) {
+      while (1) {
+        switch (_context.prev = _context.next) {
+          case 0:
+            messageId = _ref.messageId, onStoreLike = _ref.onStoreLike, onStoreLikeError = _ref.onStoreLikeError;
+            _context.next = 3;
+            return fetch('/api/likes', {
+              method: 'post',
+              headers: {
+                'Content-Type': 'application/json; charset=utf-8'
+              },
+              body: JSON.stringify({
+                message_id: messageId
+              })
+            });
+
+          case 3:
+            response = _context.sent;
+
+            if (response.ok) {
+              onStoreLike();
+            } else {
+              if (response.status === 400) {
+                onStoreLikeError();
+              } else {
+                alert('予期せぬエラーが発生しました');
+              }
+            }
+
+          case 5:
+          case "end":
+            return _context.stop();
+        }
+      }
+    }, _callee);
+  }));
+
+  return function storeLike(_x) {
+    return _ref2.apply(this, arguments);
+  };
+}();
+
+window.storeLike = storeLike;
+
+/***/ }),
+
+/***/ "./resources/js/requests/messages/destroyMessage.js":
+/*!**********************************************************!*\
+  !*** ./resources/js/requests/messages/destroyMessage.js ***!
+  \**********************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/regenerator */ "./node_modules/@babel/runtime/regenerator/index.js");
+/* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__);
+
+
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+var destroyMessage = /*#__PURE__*/function () {
+  var _ref2 = _asyncToGenerator( /*#__PURE__*/_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().mark(function _callee(_ref) {
+    var messageId, onDestroyMessage, response, _yield$response$json, data;
+
+    return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().wrap(function _callee$(_context) {
+      while (1) {
+        switch (_context.prev = _context.next) {
+          case 0:
+            messageId = _ref.messageId, onDestroyMessage = _ref.onDestroyMessage;
+            _context.next = 3;
+            return fetch("/api/messages/".concat(messageId), {
+              method: 'delete'
+            });
+
+          case 3:
+            response = _context.sent;
+
+            if (!response.ok) {
+              _context.next = 12;
+              break;
+            }
+
+            _context.next = 7;
+            return response.json();
+
+          case 7:
+            _yield$response$json = _context.sent;
+            data = _yield$response$json.data;
+            onDestroyMessage(data);
+            _context.next = 13;
+            break;
+
+          case 12:
+            alert('予期せぬエラーが発生しました。');
+
+          case 13:
+          case "end":
+            return _context.stop();
+        }
+      }
+    }, _callee);
+  }));
+
+  return function destroyMessage(_x) {
+    return _ref2.apply(this, arguments);
+  };
+}();
+
+window.destroyMessage = destroyMessage;
+
+/***/ }),
+
+/***/ "./resources/js/requests/messages/fetchMessage.js":
+/*!********************************************************!*\
+  !*** ./resources/js/requests/messages/fetchMessage.js ***!
+  \********************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/regenerator */ "./node_modules/@babel/runtime/regenerator/index.js");
+/* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__);
+
+
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+var fetchMessage = /*#__PURE__*/function () {
+  var _ref2 = _asyncToGenerator( /*#__PURE__*/_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().mark(function _callee(_ref) {
+    var link, onFetchMessage, response, _yield$response$json, data, links;
+
+    return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().wrap(function _callee$(_context) {
+      while (1) {
+        switch (_context.prev = _context.next) {
+          case 0:
+            link = _ref.link, onFetchMessage = _ref.onFetchMessage;
+            _context.next = 3;
+            return fetch(link);
+
+          case 3:
+            response = _context.sent;
+
+            if (!response.ok) {
+              _context.next = 13;
+              break;
+            }
+
+            _context.next = 7;
+            return response.json();
+
+          case 7:
+            _yield$response$json = _context.sent;
+            data = _yield$response$json.data;
+            links = _yield$response$json.links;
+            onFetchMessage({
+              data: data,
+              links: links
+            });
+            _context.next = 14;
+            break;
+
+          case 13:
+            alert('メッセージ読み込みに失敗しました。もう一度やり直してください。');
+
+          case 14:
+          case "end":
+            return _context.stop();
+        }
+      }
+    }, _callee);
+  }));
+
+  return function fetchMessage(_x) {
+    return _ref2.apply(this, arguments);
+  };
+}();
+
+window.fetchMessage = fetchMessage;
+
+/***/ }),
+
+/***/ "./resources/js/requests/messages/storeMessage.js":
+/*!********************************************************!*\
+  !*** ./resources/js/requests/messages/storeMessage.js ***!
+  \********************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/regenerator */ "./node_modules/@babel/runtime/regenerator/index.js");
+/* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__);
+
+
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+var storeMessage = /*#__PURE__*/function () {
+  var _ref2 = _asyncToGenerator( /*#__PURE__*/_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().mark(function _callee(_ref) {
+    var content, onStoreMessage, onStoreMessageError, response, _yield$response$json, data, _yield$response$json2, errors;
+
+    return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().wrap(function _callee$(_context) {
+      while (1) {
+        switch (_context.prev = _context.next) {
+          case 0:
+            content = _ref.content, onStoreMessage = _ref.onStoreMessage, onStoreMessageError = _ref.onStoreMessageError;
+            _context.next = 3;
+            return fetch('/api/messages', {
+              method: 'post',
+              headers: {
+                'Content-Type': 'application/json; charset=utf-8'
+              },
+              body: JSON.stringify({
+                content: content
+              })
+            });
+
+          case 3:
+            response = _context.sent;
+
+            if (!response.ok) {
+              _context.next = 12;
+              break;
+            }
+
+            _context.next = 7;
+            return response.json();
+
+          case 7:
+            _yield$response$json = _context.sent;
+            data = _yield$response$json.data;
+            onStoreMessage(data);
+            _context.next = 21;
+            break;
+
+          case 12:
+            if (!(response.status === 400)) {
+              _context.next = 20;
+              break;
+            }
+
+            _context.next = 15;
+            return response.json();
+
+          case 15:
+            _yield$response$json2 = _context.sent;
+            errors = _yield$response$json2.errors;
+            onStoreMessageError(errors);
+            _context.next = 21;
+            break;
+
+          case 20:
+            alert('予期せぬエラーが発生しました。');
+
+          case 21:
+          case "end":
+            return _context.stop();
+        }
+      }
+    }, _callee);
+  }));
+
+  return function storeMessage(_x) {
+    return _ref2.apply(this, arguments);
+  };
+}();
+
+window.storeMessage = storeMessage;
+
+/***/ }),
+
+/***/ "./resources/js/requests/messages/updateMessage.js":
+/*!*********************************************************!*\
+  !*** ./resources/js/requests/messages/updateMessage.js ***!
+  \*********************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/regenerator */ "./node_modules/@babel/runtime/regenerator/index.js");
+/* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__);
+
+
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+var updateMessage = /*#__PURE__*/function () {
+  var _ref2 = _asyncToGenerator( /*#__PURE__*/_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().mark(function _callee(_ref) {
+    var messageId, content, onUpdateMessage, onUpdateMessageError, response, _yield$response$json, data, _yield$response$json2, errors;
+
+    return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().wrap(function _callee$(_context) {
+      while (1) {
+        switch (_context.prev = _context.next) {
+          case 0:
+            messageId = _ref.messageId, content = _ref.content, onUpdateMessage = _ref.onUpdateMessage, onUpdateMessageError = _ref.onUpdateMessageError;
+            _context.next = 3;
+            return fetch("/api/messages/".concat(messageId), {
+              method: 'put',
+              headers: {
+                'Content-Type': 'application/json; charset=utf-8'
+              },
+              body: JSON.stringify({
+                content: content
+              })
+            });
+
+          case 3:
+            response = _context.sent;
+
+            if (!response.ok) {
+              _context.next = 12;
+              break;
+            }
+
+            _context.next = 7;
+            return response.json();
+
+          case 7:
+            _yield$response$json = _context.sent;
+            data = _yield$response$json.data;
+            onUpdateMessage(data);
+            _context.next = 21;
+            break;
+
+          case 12:
+            if (!(response.status === 400)) {
+              _context.next = 20;
+              break;
+            }
+
+            _context.next = 15;
+            return response.json();
+
+          case 15:
+            _yield$response$json2 = _context.sent;
+            errors = _yield$response$json2.errors;
+            onUpdateMessageError(errors);
+            _context.next = 21;
+            break;
+
+          case 20:
+            alert('予期せぬエラーが発生しました。');
+
+          case 21:
+          case "end":
+            return _context.stop();
+        }
+      }
+    }, _callee);
+  }));
+
+  return function updateMessage(_x) {
+    return _ref2.apply(this, arguments);
+  };
+}();
+
+window.updateMessage = updateMessage;
 
 /***/ }),
 
@@ -21252,6 +21723,764 @@ process.chdir = function (dir) {
 process.umask = function() { return 0; };
 
 
+/***/ }),
+
+/***/ "./node_modules/regenerator-runtime/runtime.js":
+/*!*****************************************************!*\
+  !*** ./node_modules/regenerator-runtime/runtime.js ***!
+  \*****************************************************/
+/***/ ((module) => {
+
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var runtime = (function (exports) {
+  "use strict";
+
+  var Op = Object.prototype;
+  var hasOwn = Op.hasOwnProperty;
+  var undefined; // More compressible than void 0.
+  var $Symbol = typeof Symbol === "function" ? Symbol : {};
+  var iteratorSymbol = $Symbol.iterator || "@@iterator";
+  var asyncIteratorSymbol = $Symbol.asyncIterator || "@@asyncIterator";
+  var toStringTagSymbol = $Symbol.toStringTag || "@@toStringTag";
+
+  function define(obj, key, value) {
+    Object.defineProperty(obj, key, {
+      value: value,
+      enumerable: true,
+      configurable: true,
+      writable: true
+    });
+    return obj[key];
+  }
+  try {
+    // IE 8 has a broken Object.defineProperty that only works on DOM objects.
+    define({}, "");
+  } catch (err) {
+    define = function(obj, key, value) {
+      return obj[key] = value;
+    };
+  }
+
+  function wrap(innerFn, outerFn, self, tryLocsList) {
+    // If outerFn provided and outerFn.prototype is a Generator, then outerFn.prototype instanceof Generator.
+    var protoGenerator = outerFn && outerFn.prototype instanceof Generator ? outerFn : Generator;
+    var generator = Object.create(protoGenerator.prototype);
+    var context = new Context(tryLocsList || []);
+
+    // The ._invoke method unifies the implementations of the .next,
+    // .throw, and .return methods.
+    generator._invoke = makeInvokeMethod(innerFn, self, context);
+
+    return generator;
+  }
+  exports.wrap = wrap;
+
+  // Try/catch helper to minimize deoptimizations. Returns a completion
+  // record like context.tryEntries[i].completion. This interface could
+  // have been (and was previously) designed to take a closure to be
+  // invoked without arguments, but in all the cases we care about we
+  // already have an existing method we want to call, so there's no need
+  // to create a new function object. We can even get away with assuming
+  // the method takes exactly one argument, since that happens to be true
+  // in every case, so we don't have to touch the arguments object. The
+  // only additional allocation required is the completion record, which
+  // has a stable shape and so hopefully should be cheap to allocate.
+  function tryCatch(fn, obj, arg) {
+    try {
+      return { type: "normal", arg: fn.call(obj, arg) };
+    } catch (err) {
+      return { type: "throw", arg: err };
+    }
+  }
+
+  var GenStateSuspendedStart = "suspendedStart";
+  var GenStateSuspendedYield = "suspendedYield";
+  var GenStateExecuting = "executing";
+  var GenStateCompleted = "completed";
+
+  // Returning this object from the innerFn has the same effect as
+  // breaking out of the dispatch switch statement.
+  var ContinueSentinel = {};
+
+  // Dummy constructor functions that we use as the .constructor and
+  // .constructor.prototype properties for functions that return Generator
+  // objects. For full spec compliance, you may wish to configure your
+  // minifier not to mangle the names of these two functions.
+  function Generator() {}
+  function GeneratorFunction() {}
+  function GeneratorFunctionPrototype() {}
+
+  // This is a polyfill for %IteratorPrototype% for environments that
+  // don't natively support it.
+  var IteratorPrototype = {};
+  IteratorPrototype[iteratorSymbol] = function () {
+    return this;
+  };
+
+  var getProto = Object.getPrototypeOf;
+  var NativeIteratorPrototype = getProto && getProto(getProto(values([])));
+  if (NativeIteratorPrototype &&
+      NativeIteratorPrototype !== Op &&
+      hasOwn.call(NativeIteratorPrototype, iteratorSymbol)) {
+    // This environment has a native %IteratorPrototype%; use it instead
+    // of the polyfill.
+    IteratorPrototype = NativeIteratorPrototype;
+  }
+
+  var Gp = GeneratorFunctionPrototype.prototype =
+    Generator.prototype = Object.create(IteratorPrototype);
+  GeneratorFunction.prototype = Gp.constructor = GeneratorFunctionPrototype;
+  GeneratorFunctionPrototype.constructor = GeneratorFunction;
+  GeneratorFunction.displayName = define(
+    GeneratorFunctionPrototype,
+    toStringTagSymbol,
+    "GeneratorFunction"
+  );
+
+  // Helper for defining the .next, .throw, and .return methods of the
+  // Iterator interface in terms of a single ._invoke method.
+  function defineIteratorMethods(prototype) {
+    ["next", "throw", "return"].forEach(function(method) {
+      define(prototype, method, function(arg) {
+        return this._invoke(method, arg);
+      });
+    });
+  }
+
+  exports.isGeneratorFunction = function(genFun) {
+    var ctor = typeof genFun === "function" && genFun.constructor;
+    return ctor
+      ? ctor === GeneratorFunction ||
+        // For the native GeneratorFunction constructor, the best we can
+        // do is to check its .name property.
+        (ctor.displayName || ctor.name) === "GeneratorFunction"
+      : false;
+  };
+
+  exports.mark = function(genFun) {
+    if (Object.setPrototypeOf) {
+      Object.setPrototypeOf(genFun, GeneratorFunctionPrototype);
+    } else {
+      genFun.__proto__ = GeneratorFunctionPrototype;
+      define(genFun, toStringTagSymbol, "GeneratorFunction");
+    }
+    genFun.prototype = Object.create(Gp);
+    return genFun;
+  };
+
+  // Within the body of any async function, `await x` is transformed to
+  // `yield regeneratorRuntime.awrap(x)`, so that the runtime can test
+  // `hasOwn.call(value, "__await")` to determine if the yielded value is
+  // meant to be awaited.
+  exports.awrap = function(arg) {
+    return { __await: arg };
+  };
+
+  function AsyncIterator(generator, PromiseImpl) {
+    function invoke(method, arg, resolve, reject) {
+      var record = tryCatch(generator[method], generator, arg);
+      if (record.type === "throw") {
+        reject(record.arg);
+      } else {
+        var result = record.arg;
+        var value = result.value;
+        if (value &&
+            typeof value === "object" &&
+            hasOwn.call(value, "__await")) {
+          return PromiseImpl.resolve(value.__await).then(function(value) {
+            invoke("next", value, resolve, reject);
+          }, function(err) {
+            invoke("throw", err, resolve, reject);
+          });
+        }
+
+        return PromiseImpl.resolve(value).then(function(unwrapped) {
+          // When a yielded Promise is resolved, its final value becomes
+          // the .value of the Promise<{value,done}> result for the
+          // current iteration.
+          result.value = unwrapped;
+          resolve(result);
+        }, function(error) {
+          // If a rejected Promise was yielded, throw the rejection back
+          // into the async generator function so it can be handled there.
+          return invoke("throw", error, resolve, reject);
+        });
+      }
+    }
+
+    var previousPromise;
+
+    function enqueue(method, arg) {
+      function callInvokeWithMethodAndArg() {
+        return new PromiseImpl(function(resolve, reject) {
+          invoke(method, arg, resolve, reject);
+        });
+      }
+
+      return previousPromise =
+        // If enqueue has been called before, then we want to wait until
+        // all previous Promises have been resolved before calling invoke,
+        // so that results are always delivered in the correct order. If
+        // enqueue has not been called before, then it is important to
+        // call invoke immediately, without waiting on a callback to fire,
+        // so that the async generator function has the opportunity to do
+        // any necessary setup in a predictable way. This predictability
+        // is why the Promise constructor synchronously invokes its
+        // executor callback, and why async functions synchronously
+        // execute code before the first await. Since we implement simple
+        // async functions in terms of async generators, it is especially
+        // important to get this right, even though it requires care.
+        previousPromise ? previousPromise.then(
+          callInvokeWithMethodAndArg,
+          // Avoid propagating failures to Promises returned by later
+          // invocations of the iterator.
+          callInvokeWithMethodAndArg
+        ) : callInvokeWithMethodAndArg();
+    }
+
+    // Define the unified helper method that is used to implement .next,
+    // .throw, and .return (see defineIteratorMethods).
+    this._invoke = enqueue;
+  }
+
+  defineIteratorMethods(AsyncIterator.prototype);
+  AsyncIterator.prototype[asyncIteratorSymbol] = function () {
+    return this;
+  };
+  exports.AsyncIterator = AsyncIterator;
+
+  // Note that simple async functions are implemented on top of
+  // AsyncIterator objects; they just return a Promise for the value of
+  // the final result produced by the iterator.
+  exports.async = function(innerFn, outerFn, self, tryLocsList, PromiseImpl) {
+    if (PromiseImpl === void 0) PromiseImpl = Promise;
+
+    var iter = new AsyncIterator(
+      wrap(innerFn, outerFn, self, tryLocsList),
+      PromiseImpl
+    );
+
+    return exports.isGeneratorFunction(outerFn)
+      ? iter // If outerFn is a generator, return the full iterator.
+      : iter.next().then(function(result) {
+          return result.done ? result.value : iter.next();
+        });
+  };
+
+  function makeInvokeMethod(innerFn, self, context) {
+    var state = GenStateSuspendedStart;
+
+    return function invoke(method, arg) {
+      if (state === GenStateExecuting) {
+        throw new Error("Generator is already running");
+      }
+
+      if (state === GenStateCompleted) {
+        if (method === "throw") {
+          throw arg;
+        }
+
+        // Be forgiving, per 25.3.3.3.3 of the spec:
+        // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-generatorresume
+        return doneResult();
+      }
+
+      context.method = method;
+      context.arg = arg;
+
+      while (true) {
+        var delegate = context.delegate;
+        if (delegate) {
+          var delegateResult = maybeInvokeDelegate(delegate, context);
+          if (delegateResult) {
+            if (delegateResult === ContinueSentinel) continue;
+            return delegateResult;
+          }
+        }
+
+        if (context.method === "next") {
+          // Setting context._sent for legacy support of Babel's
+          // function.sent implementation.
+          context.sent = context._sent = context.arg;
+
+        } else if (context.method === "throw") {
+          if (state === GenStateSuspendedStart) {
+            state = GenStateCompleted;
+            throw context.arg;
+          }
+
+          context.dispatchException(context.arg);
+
+        } else if (context.method === "return") {
+          context.abrupt("return", context.arg);
+        }
+
+        state = GenStateExecuting;
+
+        var record = tryCatch(innerFn, self, context);
+        if (record.type === "normal") {
+          // If an exception is thrown from innerFn, we leave state ===
+          // GenStateExecuting and loop back for another invocation.
+          state = context.done
+            ? GenStateCompleted
+            : GenStateSuspendedYield;
+
+          if (record.arg === ContinueSentinel) {
+            continue;
+          }
+
+          return {
+            value: record.arg,
+            done: context.done
+          };
+
+        } else if (record.type === "throw") {
+          state = GenStateCompleted;
+          // Dispatch the exception by looping back around to the
+          // context.dispatchException(context.arg) call above.
+          context.method = "throw";
+          context.arg = record.arg;
+        }
+      }
+    };
+  }
+
+  // Call delegate.iterator[context.method](context.arg) and handle the
+  // result, either by returning a { value, done } result from the
+  // delegate iterator, or by modifying context.method and context.arg,
+  // setting context.delegate to null, and returning the ContinueSentinel.
+  function maybeInvokeDelegate(delegate, context) {
+    var method = delegate.iterator[context.method];
+    if (method === undefined) {
+      // A .throw or .return when the delegate iterator has no .throw
+      // method always terminates the yield* loop.
+      context.delegate = null;
+
+      if (context.method === "throw") {
+        // Note: ["return"] must be used for ES3 parsing compatibility.
+        if (delegate.iterator["return"]) {
+          // If the delegate iterator has a return method, give it a
+          // chance to clean up.
+          context.method = "return";
+          context.arg = undefined;
+          maybeInvokeDelegate(delegate, context);
+
+          if (context.method === "throw") {
+            // If maybeInvokeDelegate(context) changed context.method from
+            // "return" to "throw", let that override the TypeError below.
+            return ContinueSentinel;
+          }
+        }
+
+        context.method = "throw";
+        context.arg = new TypeError(
+          "The iterator does not provide a 'throw' method");
+      }
+
+      return ContinueSentinel;
+    }
+
+    var record = tryCatch(method, delegate.iterator, context.arg);
+
+    if (record.type === "throw") {
+      context.method = "throw";
+      context.arg = record.arg;
+      context.delegate = null;
+      return ContinueSentinel;
+    }
+
+    var info = record.arg;
+
+    if (! info) {
+      context.method = "throw";
+      context.arg = new TypeError("iterator result is not an object");
+      context.delegate = null;
+      return ContinueSentinel;
+    }
+
+    if (info.done) {
+      // Assign the result of the finished delegate to the temporary
+      // variable specified by delegate.resultName (see delegateYield).
+      context[delegate.resultName] = info.value;
+
+      // Resume execution at the desired location (see delegateYield).
+      context.next = delegate.nextLoc;
+
+      // If context.method was "throw" but the delegate handled the
+      // exception, let the outer generator proceed normally. If
+      // context.method was "next", forget context.arg since it has been
+      // "consumed" by the delegate iterator. If context.method was
+      // "return", allow the original .return call to continue in the
+      // outer generator.
+      if (context.method !== "return") {
+        context.method = "next";
+        context.arg = undefined;
+      }
+
+    } else {
+      // Re-yield the result returned by the delegate method.
+      return info;
+    }
+
+    // The delegate iterator is finished, so forget it and continue with
+    // the outer generator.
+    context.delegate = null;
+    return ContinueSentinel;
+  }
+
+  // Define Generator.prototype.{next,throw,return} in terms of the
+  // unified ._invoke helper method.
+  defineIteratorMethods(Gp);
+
+  define(Gp, toStringTagSymbol, "Generator");
+
+  // A Generator should always return itself as the iterator object when the
+  // @@iterator function is called on it. Some browsers' implementations of the
+  // iterator prototype chain incorrectly implement this, causing the Generator
+  // object to not be returned from this call. This ensures that doesn't happen.
+  // See https://github.com/facebook/regenerator/issues/274 for more details.
+  Gp[iteratorSymbol] = function() {
+    return this;
+  };
+
+  Gp.toString = function() {
+    return "[object Generator]";
+  };
+
+  function pushTryEntry(locs) {
+    var entry = { tryLoc: locs[0] };
+
+    if (1 in locs) {
+      entry.catchLoc = locs[1];
+    }
+
+    if (2 in locs) {
+      entry.finallyLoc = locs[2];
+      entry.afterLoc = locs[3];
+    }
+
+    this.tryEntries.push(entry);
+  }
+
+  function resetTryEntry(entry) {
+    var record = entry.completion || {};
+    record.type = "normal";
+    delete record.arg;
+    entry.completion = record;
+  }
+
+  function Context(tryLocsList) {
+    // The root entry object (effectively a try statement without a catch
+    // or a finally block) gives us a place to store values thrown from
+    // locations where there is no enclosing try statement.
+    this.tryEntries = [{ tryLoc: "root" }];
+    tryLocsList.forEach(pushTryEntry, this);
+    this.reset(true);
+  }
+
+  exports.keys = function(object) {
+    var keys = [];
+    for (var key in object) {
+      keys.push(key);
+    }
+    keys.reverse();
+
+    // Rather than returning an object with a next method, we keep
+    // things simple and return the next function itself.
+    return function next() {
+      while (keys.length) {
+        var key = keys.pop();
+        if (key in object) {
+          next.value = key;
+          next.done = false;
+          return next;
+        }
+      }
+
+      // To avoid creating an additional object, we just hang the .value
+      // and .done properties off the next function object itself. This
+      // also ensures that the minifier will not anonymize the function.
+      next.done = true;
+      return next;
+    };
+  };
+
+  function values(iterable) {
+    if (iterable) {
+      var iteratorMethod = iterable[iteratorSymbol];
+      if (iteratorMethod) {
+        return iteratorMethod.call(iterable);
+      }
+
+      if (typeof iterable.next === "function") {
+        return iterable;
+      }
+
+      if (!isNaN(iterable.length)) {
+        var i = -1, next = function next() {
+          while (++i < iterable.length) {
+            if (hasOwn.call(iterable, i)) {
+              next.value = iterable[i];
+              next.done = false;
+              return next;
+            }
+          }
+
+          next.value = undefined;
+          next.done = true;
+
+          return next;
+        };
+
+        return next.next = next;
+      }
+    }
+
+    // Return an iterator with no values.
+    return { next: doneResult };
+  }
+  exports.values = values;
+
+  function doneResult() {
+    return { value: undefined, done: true };
+  }
+
+  Context.prototype = {
+    constructor: Context,
+
+    reset: function(skipTempReset) {
+      this.prev = 0;
+      this.next = 0;
+      // Resetting context._sent for legacy support of Babel's
+      // function.sent implementation.
+      this.sent = this._sent = undefined;
+      this.done = false;
+      this.delegate = null;
+
+      this.method = "next";
+      this.arg = undefined;
+
+      this.tryEntries.forEach(resetTryEntry);
+
+      if (!skipTempReset) {
+        for (var name in this) {
+          // Not sure about the optimal order of these conditions:
+          if (name.charAt(0) === "t" &&
+              hasOwn.call(this, name) &&
+              !isNaN(+name.slice(1))) {
+            this[name] = undefined;
+          }
+        }
+      }
+    },
+
+    stop: function() {
+      this.done = true;
+
+      var rootEntry = this.tryEntries[0];
+      var rootRecord = rootEntry.completion;
+      if (rootRecord.type === "throw") {
+        throw rootRecord.arg;
+      }
+
+      return this.rval;
+    },
+
+    dispatchException: function(exception) {
+      if (this.done) {
+        throw exception;
+      }
+
+      var context = this;
+      function handle(loc, caught) {
+        record.type = "throw";
+        record.arg = exception;
+        context.next = loc;
+
+        if (caught) {
+          // If the dispatched exception was caught by a catch block,
+          // then let that catch block handle the exception normally.
+          context.method = "next";
+          context.arg = undefined;
+        }
+
+        return !! caught;
+      }
+
+      for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+        var entry = this.tryEntries[i];
+        var record = entry.completion;
+
+        if (entry.tryLoc === "root") {
+          // Exception thrown outside of any try block that could handle
+          // it, so set the completion value of the entire function to
+          // throw the exception.
+          return handle("end");
+        }
+
+        if (entry.tryLoc <= this.prev) {
+          var hasCatch = hasOwn.call(entry, "catchLoc");
+          var hasFinally = hasOwn.call(entry, "finallyLoc");
+
+          if (hasCatch && hasFinally) {
+            if (this.prev < entry.catchLoc) {
+              return handle(entry.catchLoc, true);
+            } else if (this.prev < entry.finallyLoc) {
+              return handle(entry.finallyLoc);
+            }
+
+          } else if (hasCatch) {
+            if (this.prev < entry.catchLoc) {
+              return handle(entry.catchLoc, true);
+            }
+
+          } else if (hasFinally) {
+            if (this.prev < entry.finallyLoc) {
+              return handle(entry.finallyLoc);
+            }
+
+          } else {
+            throw new Error("try statement without catch or finally");
+          }
+        }
+      }
+    },
+
+    abrupt: function(type, arg) {
+      for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+        var entry = this.tryEntries[i];
+        if (entry.tryLoc <= this.prev &&
+            hasOwn.call(entry, "finallyLoc") &&
+            this.prev < entry.finallyLoc) {
+          var finallyEntry = entry;
+          break;
+        }
+      }
+
+      if (finallyEntry &&
+          (type === "break" ||
+           type === "continue") &&
+          finallyEntry.tryLoc <= arg &&
+          arg <= finallyEntry.finallyLoc) {
+        // Ignore the finally entry if control is not jumping to a
+        // location outside the try/catch block.
+        finallyEntry = null;
+      }
+
+      var record = finallyEntry ? finallyEntry.completion : {};
+      record.type = type;
+      record.arg = arg;
+
+      if (finallyEntry) {
+        this.method = "next";
+        this.next = finallyEntry.finallyLoc;
+        return ContinueSentinel;
+      }
+
+      return this.complete(record);
+    },
+
+    complete: function(record, afterLoc) {
+      if (record.type === "throw") {
+        throw record.arg;
+      }
+
+      if (record.type === "break" ||
+          record.type === "continue") {
+        this.next = record.arg;
+      } else if (record.type === "return") {
+        this.rval = this.arg = record.arg;
+        this.method = "return";
+        this.next = "end";
+      } else if (record.type === "normal" && afterLoc) {
+        this.next = afterLoc;
+      }
+
+      return ContinueSentinel;
+    },
+
+    finish: function(finallyLoc) {
+      for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+        var entry = this.tryEntries[i];
+        if (entry.finallyLoc === finallyLoc) {
+          this.complete(entry.completion, entry.afterLoc);
+          resetTryEntry(entry);
+          return ContinueSentinel;
+        }
+      }
+    },
+
+    "catch": function(tryLoc) {
+      for (var i = this.tryEntries.length - 1; i >= 0; --i) {
+        var entry = this.tryEntries[i];
+        if (entry.tryLoc === tryLoc) {
+          var record = entry.completion;
+          if (record.type === "throw") {
+            var thrown = record.arg;
+            resetTryEntry(entry);
+          }
+          return thrown;
+        }
+      }
+
+      // The context.catch method must only be called with a location
+      // argument that corresponds to a known catch block.
+      throw new Error("illegal catch attempt");
+    },
+
+    delegateYield: function(iterable, resultName, nextLoc) {
+      this.delegate = {
+        iterator: values(iterable),
+        resultName: resultName,
+        nextLoc: nextLoc
+      };
+
+      if (this.method === "next") {
+        // Deliberately forget the last sent value so that we don't
+        // accidentally pass it on to the delegate.
+        this.arg = undefined;
+      }
+
+      return ContinueSentinel;
+    }
+  };
+
+  // Regardless of whether this script is executing as a CommonJS module
+  // or not, return the runtime object so that we can declare the variable
+  // regeneratorRuntime in the outer scope, which allows this module to be
+  // injected easily by `bin/regenerator --include-runtime script.js`.
+  return exports;
+
+}(
+  // If this script is executing as a CommonJS module, use module.exports
+  // as the regeneratorRuntime namespace. Otherwise create a new empty
+  // object. Either way, the resulting object will be used to initialize
+  // the regeneratorRuntime variable at the top of this file.
+   true ? module.exports : 0
+));
+
+try {
+  regeneratorRuntime = runtime;
+} catch (accidentalStrictMode) {
+  // This module should not be running in strict mode, so the above
+  // assignment should always work unless something is misconfigured. Just
+  // in case runtime.js accidentally runs in strict mode, we can escape
+  // strict mode using a global Function call. This could conceivably fail
+  // if a Content Security Policy forbids using Function, but in that case
+  // the proper solution is to fix the accidental strict mode problem. If
+  // you've misconfigured your bundler to force strict mode and applied a
+  // CSP to forbid Function, and you're not willing to fix either of those
+  // problems, please detail your unique predicament in a GitHub issue.
+  Function("r", "regeneratorRuntime = r")(runtime);
+}
+
+
 /***/ })
 
 /******/ 	});
@@ -21315,6 +22544,30 @@ process.umask = function() { return 0; };
 /******/ 				}
 /******/ 			}
 /******/ 			return result;
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	(() => {
+/******/ 		// getDefaultExport function for compatibility with non-harmony modules
+/******/ 		__webpack_require__.n = (module) => {
+/******/ 			var getter = module && module.__esModule ?
+/******/ 				() => (module['default']) :
+/******/ 				() => (module);
+/******/ 			__webpack_require__.d(getter, { a: getter });
+/******/ 			return getter;
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	(() => {
+/******/ 		// define getter functions for harmony exports
+/******/ 		__webpack_require__.d = (exports, definition) => {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
+/******/ 			}
 /******/ 		};
 /******/ 	})();
 /******/ 	

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,3 +1,10 @@
 require('./bootstrap');
 
+require('./requests/likes/storeLike');
+require('./requests/likes/destroyLike');
+require('./requests/messages/fetchMessage');
+require('./requests/messages/storeMessage');
+require('./requests/messages/updateMessage');
+require('./requests/messages/destroyMessage');
+
 require('alpinejs');

--- a/resources/js/requests/likes/destroyLike.js
+++ b/resources/js/requests/likes/destroyLike.js
@@ -1,0 +1,23 @@
+const destroyLike = async ({
+    messageId,
+    onDestroyLike,
+    onDestroyLikeError,
+}) => {
+    const response = await fetch('/api/likes', {
+        method: 'delete',
+        headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+        },
+        body: JSON.stringify({ message_id: messageId }),
+    });
+    if (response.ok) {
+        onDestroyLike();
+    } else {
+        if (response.status === 400) {
+            onDestroyLikeError();
+        } else {
+            alert('予期せぬエラーが発生しました');
+        }
+    }
+};
+window.destroyLike = destroyLike;

--- a/resources/js/requests/likes/storeLike.js
+++ b/resources/js/requests/likes/storeLike.js
@@ -1,0 +1,23 @@
+const storeLike = async ({
+    messageId,
+    onStoreLike,
+    onStoreLikeError,
+}) => {
+    const response = await fetch('/api/likes', {
+        method: 'post',
+        headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+        },
+        body: JSON.stringify({ message_id: messageId }),
+    });
+    if (response.ok) {
+        onStoreLike();
+    } else {
+        if (response.status === 400) {
+            onStoreLikeError()
+        } else {
+            alert('予期せぬエラーが発生しました');
+        }
+    }
+};
+window.storeLike = storeLike;

--- a/resources/js/requests/messages/destroyMessage.js
+++ b/resources/js/requests/messages/destroyMessage.js
@@ -1,0 +1,15 @@
+const destroyMessage = async ({
+    messageId,
+    onDestroyMessage,
+}) => {
+    const response = await fetch(`/api/messages/${messageId}`, {
+        method: 'delete',
+    });
+    if (response.ok) {
+        const { data } = await response.json();
+        onDestroyMessage(data);
+    } else {
+        alert('予期せぬエラーが発生しました。');
+    }
+};
+window.destroyMessage = destroyMessage;

--- a/resources/js/requests/messages/fetchMessage.js
+++ b/resources/js/requests/messages/fetchMessage.js
@@ -1,0 +1,13 @@
+const fetchMessage = async ({
+    link,
+    onFetchMessage,
+}) => {
+    const response = await fetch(link);
+    if (response.ok) {
+        const { data, links } = await response.json();
+        onFetchMessage({ data, links });
+    } else {
+        alert('メッセージ読み込みに失敗しました。もう一度やり直してください。')
+    }
+};
+window.fetchMessage = fetchMessage;

--- a/resources/js/requests/messages/storeMessage.js
+++ b/resources/js/requests/messages/storeMessage.js
@@ -1,0 +1,25 @@
+const storeMessage = async ({
+    content,
+    onStoreMessage,
+    onStoreMessageError,
+}) => {
+    const response = await fetch('/api/messages', {
+        method: 'post',
+        headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+        },
+        body: JSON.stringify({ content }),
+    });
+    if (response.ok) {
+        const { data } = await response.json();
+        onStoreMessage(data);
+    } else {
+        if (response.status === 400) {
+            const { errors } = await response.json();
+            onStoreMessageError(errors);
+        } else {
+            alert('予期せぬエラーが発生しました。');
+        }
+    }
+};
+window.storeMessage = storeMessage;

--- a/resources/js/requests/messages/updateMessage.js
+++ b/resources/js/requests/messages/updateMessage.js
@@ -1,0 +1,26 @@
+const updateMessage = async ({
+    messageId,
+    content,
+    onUpdateMessage,
+    onUpdateMessageError,
+}) => {
+    const response = await fetch(`/api/messages/${messageId}`, {
+        method: 'put',
+        headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+        },
+        body: JSON.stringify({ content }),
+    });
+    if (response.ok) {
+        const { data } = await response.json();
+        onUpdateMessage(data);
+    } else {
+        if (response.status === 400) {
+            const { errors } = await response.json();
+            onUpdateMessageError(errors);
+        } else {
+            alert('予期せぬエラーが発生しました。');
+        }
+    }
+};
+window.updateMessage = updateMessage;

--- a/resources/views/components/message-cards.blade.php
+++ b/resources/views/components/message-cards.blade.php
@@ -1,7 +1,8 @@
 <template x-for="item in items">
     <div class="mx-3 my-5 relative bg-white rounded-lg shadow-md">
         <div class="flex justify-between py-4 px-6">
-            <div class="text-gray-dark flex items-center" x-text="item.updated_at">
+            <div class="text-gray-dark flex items-center">
+                <span x-text="item.updated_at"></span>
                 <template x-if="item.isEdited">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 ml-2" viewBox="0 0 20 20" fill="currentColor">
                         <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
@@ -27,14 +28,14 @@
                         >
                             <div class="rounded-md ring-1 ring-black ring-opacity-5">
                                 <a
-                                    x-bind:href="`/messages/${item.id}`"
                                     class="block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out text-green-600"
+                                    @click="event.preventDefault();item.isEditing = true;"
                                 >
                                     編集
                                 </a>
                                 <a
                                     class="block px-4 py-2 text-sm text-red-600 leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out"
-                                    @click="event.preventDefault();console.log('削除')"
+                                    @click="event.preventDefault();deleteItem(item.id);"
                                 >
                                     削除
                                 </a>
@@ -44,7 +45,42 @@
                 </template>
             </div>
         </div>
-        <p class="px-10 pt-8 py-6 text-lg text-gray-darkest leading-relaxed" x-html="item.content"></p>
+
+
+        <template x-if="item.isEditing">
+            <div class="w-full bg-white p-4 my-4 text-gray-700">
+                <template x-if="item.errors.length > 0">
+                    <ul class="my-3 list-disc list-inside text-sm text-red-600">
+                        <template x-for="error in item.errors">
+                            <li x-text="error"></li>
+                        </template>
+                    </ul>
+                </template>
+
+                <div class="flex flex-wrap mb-6">
+                    <div class="relative w-full appearance-none label-floating">
+                        <textarea name="content" class="autoexpand tracking-wide py-2 px-4 mb-3 leading-relaxed appearance-none block w-full bg-gray-200 border border-gray-200 rounded focus:outline-none focus:bg-white focus:border-gray-500" id="message" placeholder="Message..." rows="5" x-model="item.content"></textarea>
+                        <label for="message" class="absolute tracking-wide py-2 px-4 mb-4 opacity-0 leading-tight block top-0 left-0 cursor-text">Message...
+                        </label>
+                    </div>
+                </div>
+
+                <div class="flex justify-between">
+                    <button
+                        class="inline-flex items-center px-4 py-2 bg-white-800 border border-transparent rounded-md font-semibold text-xs text-gray uppercase tracking-widest hover:bg-white-700 active:bg-white-900 focus:outline-none focus:border-gray-900 focus:ring ring-white-300 disabled:opacity-25 transition ease-in-out duration-150"
+                        @click="cancelEdit(item)"
+                    >
+                        戻る
+                    </button>
+                    <x-button type="button" class="ml-3" @click="editItem(item)">編集</x-button>
+                </div>
+            </div>
+        </template>
+        <template x-if="!item.isEditing">
+            <p class="px-10 pt-8 py-6 text-lg text-gray-darkest leading-relaxed" x-html="item.content.replace(/\r\n/g, '<br>')"></p>
+        </template>
+
+
         <template x-if="user !== null">
             <p class="pb-4 flex justify-end items-center">
                 <template x-if="item.isLiked">

--- a/resources/views/components/message-cards.blade.php
+++ b/resources/views/components/message-cards.blade.php
@@ -77,7 +77,7 @@
             </div>
         </template>
         <template x-if="!item.isEditing">
-            <p class="px-10 pt-8 py-6 text-lg text-gray-darkest leading-relaxed" x-html="item.content.replace(/\r\n/g, '<br>')"></p>
+            <p class="px-10 pt-8 py-6 text-lg text-gray-darkest leading-relaxed" x-html="item.content.replace(/[\n|\r|\n\r]/g, '<br>')"></p>
         </template>
 
 
@@ -87,10 +87,7 @@
                     <button
                         class="focus:outline-none"
                         type="button"
-                        @click="requestLike({ isLiked: item.isLiked, messageId: item.id }).then(() => {
-                            item.isLiked = false;
-                            item.likedCount--;
-                        });"
+                        @click="unlikeItem(item)"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="red" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
@@ -101,10 +98,7 @@
                     <button
                         class="focus:outline-none"
                         type="button"
-                        @click="requestLike({ isLiked: item.isLiked, messageId: item.id }).then(() => {
-                            item.isLiked = true;
-                            item.likedCount++;
-                        });"
+                        @click="likeItem(item)"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />

--- a/resources/views/components/message-create-form.blade.php
+++ b/resources/views/components/message-create-form.blade.php
@@ -1,22 +1,27 @@
-@props(['content'])
+<div class="w-full bg-white shadow p-8 my-8 text-gray-700">
+    <template x-if="errors.length > 0">
+        <ul class="my-3 list-disc list-inside text-sm text-red-600">
+            <template x-for="error in errors">
+                <li x-text="error"></li>
+            </template>
+        </ul>
+    </template>
 
-<form action="{{ route('messages.store') }}" method="post" class="w-full bg-white shadow p-8 my-8 text-gray-700">
-    @csrf
-
-    <!-- Validation Errors -->
-    <x-auth-validation-errors class="mb-4" :errors="$errors" />
-
-    <!-- Message field -->
     <div class="flex flex-wrap mb-6">
         <div class="relative w-full appearance-none label-floating">
-            <textarea name="content" class="autoexpand tracking-wide py-2 px-4 mb-3 leading-relaxed appearance-none block w-full bg-gray-200 border border-gray-200 rounded focus:outline-none focus:bg-white focus:border-gray-500" id="message" placeholder="Message..." rows="5">{{ $content ?? '' }}</textarea>
+            <textarea name="content" class="autoexpand tracking-wide py-2 px-4 mb-3 leading-relaxed appearance-none block w-full bg-gray-200 border border-gray-200 rounded focus:outline-none focus:bg-white focus:border-gray-500" id="message" placeholder="Message..." rows="5" x-model="newContent"></textarea>
             <label for="message" class="absolute tracking-wide py-2 px-4 mb-4 opacity-0 leading-tight block top-0 left-0 cursor-text">Message...
             </label>
         </div>
     </div>
 
     <div class="flex justify-end">
-        <x-button class="ml-3">投稿</x-button>
+        <x-button
+            type="button"
+            class="ml-3"
+            @click="createItem({ content: newContent })"
+        >
+            投稿
+        </x-button>
     </div>
-</form>
-<hr>
+</div>

--- a/resources/views/default/index.blade.php
+++ b/resources/views/default/index.blade.php
@@ -26,25 +26,6 @@
 <script>
     const user = @json(Auth::user());
 
-    const requestLike = ({ isLiked, messageId }) => {
-        if (!isLiked) {
-            return fetch('/api/likes', {
-                method: 'post',
-                headers: {
-                    'Content-Type': 'application/json; charset=utf-8',
-                },
-                body: JSON.stringify({ message_id: messageId }),
-            });
-        }
-        return fetch('/api/likes', {
-            method: 'delete',
-            headers: {
-                'Content-Type': 'application/json; charset=utf-8',
-            },
-            body: JSON.stringify({ message_id: messageId }),
-        });
-    }
-
     function infiniteScroll() {
         return {
             triggerElement: null,
@@ -83,62 +64,52 @@
                             ctx.getItems()
                         }
                     }, { threshold: [0] })
-
                     this.observer.observe(this.triggerElement)
                 }
             },
             async getItems() {
-                const response = await fetch(this.nextLink);
-                const { data, links } = await response.json();
-
-                this.nextLink = links.next;
-                this.items = this.items.concat(data.map(v => ({
-                    ...v,
-                    tmpContent: v.content,
-                    open: false,
-                    isEditing: false,
-                    errors: [],
-                })));
-                if(this.nextLink === null) {
-                    if(this.isObserverPolyfilled) {
-                        window.removeEventListener('scroll', window.alpineInfiniteScroll.scrollFunc)
-                    } else {
-                        this.observer.unobserve(this.triggerElement)
-                    }
-
-                    this.triggerElement.parentNode.removeChild(this.triggerElement)
-                }
+                await fetchMessage({
+                    link: this.nextLink,
+                    onFetchMessage: ({ data, links }) => {
+                        this.nextLink = links.next;
+                        this.items = this.items.concat(data.map(v => ({
+                            ...v,
+                            tmpContent: v.content,
+                            open: false,
+                            isEditing: false,
+                            errors: [],
+                        })));
+                        if (this.nextLink === null) {
+                            if (this.isObserverPolyfilled) {
+                                window.removeEventListener('scroll', window.alpineInfiniteScroll.scrollFunc)
+                            } else {
+                                this.observer.unobserve(this.triggerElement)
+                            }
+                            this.triggerElement.parentNode.removeChild(this.triggerElement)
+                        }
+                    },
+                });
             },
             async createItem({ content }) {
-                const response = await fetch('/api/messages', {
-                    method: 'post',
-                    headers: {
-                        'Content-Type': 'application/json; charset=utf-8',
+                await storeMessage({
+                    content,
+                    onStoreMessage: (data) => {
+                        this.items.unshift({
+                            ...data,
+                            tmpContent: content,
+                            open: false,
+                            isEditing: false,
+                            errors: [],
+                        });
+                        this.newContent = '';
+                        this.errors = [];
                     },
-                    body: JSON.stringify({ content }),
-                });
-                if (response.ok) {
-                    const { data } = await response.json();
-                    this.items.unshift({
-                        ...data,
-                        tmpContent: content,
-                        open: false,
-                        isEditing: false,
-                        errors: [],
-                    });
-                    this.newContent = '';
-                    this.errors = [];
-                } else {
-                    if (response.status === 400) {
-                        const { errors } = await response.json();
+                    onStoreMessageError: (errors) => {
                         for (let k in errors) {
                             this.errors.push(...errors[k]);
                         }
-                    } else {
-                        alert('予期せぬエラーが発生しましtあ。');
-                    }
-                }
-
+                    },
+                });
             },
             cancelEdit(item) {
                 item.content = item.tmpContent;
@@ -146,41 +117,51 @@
                 item.errors = [];
             },
             async editItem(item) {
-                const response = await fetch(`/api/messages/${item.id}`, {
-                    method: 'put',
-                    headers: {
-                        'Content-Type': 'application/json; charset=utf-8',
+                await updateMessage({
+                    messageId: item.id,
+                    content: item.content,
+                    onUpdateMessage: (data) => {
+                        item.updated_at = data.updated_at;
+                        item.isEdited = true;
+                        item.isEditing = false;
+                        item.tmpContent = item.content;
+                        item.errors = [];
                     },
-                    body: JSON.stringify({ content: item.content }),
-                });
-                if (response.ok) {
-                    const { data } = await response.json();
-                    item.updated_at = data.updated_at;
-                    item.isEdited = true;
-                    item.isEditing = false;
-                    item.tmpContent = item.content;
-                    item.errors = [];
-                } else {
-                    if (response.status === 400) {
-                        const { errors } = await response.json();
+                    onUpdateMessageError: (errors) => {
                         for (let k in errors) {
                             item.errors.push(...errors[k]);
                         }
-                    } else {
-                        alert('予期せぬエラーが発生しましtあ。');
-                    }
-                }
+                    },
+                })
             },
             async deleteItem(messageId) {
-                const response = await fetch(`/api/messages/${messageId}`, {
-                    method: 'delete',
+                await destroyMessage({
+                    messageId,
+                    onDestroyMessage: () => {
+                        this.items = this.items.filter(item => item.id !== messageId);
+                    },
                 });
-                if (response.ok) {
-                    this.items = this.items.filter(item => item.id !== messageId);
-                } else {
-                    alert('削除に失敗しました。もう一度やり直してください。');
-                }
-            }
-        }
+            },
+            async likeItem(item) {
+                await storeLike({
+                    messageId: item.id,
+                    onStoreLike: () => {
+                        item.isLiked = true;
+                        item.likedCount++;
+                    },
+                    onStoreLikeError: () => {},
+                });
+            },
+            async unlikeItem(item) {
+                await destroyLike({
+                    messageId: item.id,
+                    onDestroyLike: () => {
+                        item.isLiked = false;
+                        item.likedCount--;
+                    },
+                    onDestroyLikeError: () => {},
+                });
+            },
+        };
     }
 </script>

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,9 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 });
 
 Route::get('/messages', [MessageController::class, 'index']);
+Route::delete('/messages/{message}', [MessageController::class, 'destroy'])
+    ->middleware('can:destroy,message')
+    ->name('api.messages.destroy');
 
 Route::post('/likes', [LikeController::class, 'store'])
     ->middleware('auth')

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,9 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 });
 
 Route::get('/messages', [MessageController::class, 'index']);
+Route::post('/messages', [MessageController::class, 'store'])
+    ->middleware('auth')
+    ->name('api.messages.store');
 Route::put('/messages/{message}', [MessageController::class, 'update'])
     ->middleware('can:update,message')
     ->name('api.messages.update');

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,9 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 });
 
 Route::get('/messages', [MessageController::class, 'index']);
+Route::put('/messages/{message}', [MessageController::class, 'update'])
+    ->middleware('can:update,message')
+    ->name('api.messages.update');
 Route::delete('/messages/{message}', [MessageController::class, 'destroy'])
     ->middleware('can:destroy,message')
     ->name('api.messages.destroy');

--- a/tests/Feature/Controllers/Api/MessageControllerTest.php
+++ b/tests/Feature/Controllers/Api/MessageControllerTest.php
@@ -60,7 +60,7 @@ class MessageControllerTest extends TestCase
     {
         $user = User::factory()->create();
         $response = $this->actingAs($user)->post('/api/messages', [
-            'content' => $this->faker->realTextBetween(),
+            'content' => $this->faker->realTextBetween(141),
         ]);
 
         $response->assertStatus(400);
@@ -114,7 +114,7 @@ class MessageControllerTest extends TestCase
     {
         $message = Message::factory()->create();
         $response = $this->actingAs($message->user)->put('/api/messages/' . $message->id, [
-            'content' => $this->faker->realTextBetween(),
+            'content' => $this->faker->realTextBetween(141),
         ]);
 
         // Messageが更新されていないかどうか

--- a/tests/Feature/Controllers/Api/MessageControllerTest.php
+++ b/tests/Feature/Controllers/Api/MessageControllerTest.php
@@ -5,13 +5,14 @@ namespace Tests\Feature\Controllers\Api;
 use App\Http\Resources\MessageResource;
 use App\Models\Message;
 use App\Models\User;
-use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class MessageControllerTest extends TestCase
 {
     use RefreshDatabase;
+    use WithFaker;
 
     public function test_messages_can_be_returned()
     {
@@ -23,6 +24,71 @@ class MessageControllerTest extends TestCase
             json_encode($response->json('data'))
         );
         $response->assertSuccessful();
+    }
+
+    public function test_message_can_be_updated()
+    {
+        $message = Message::factory()->create();
+        $response = $this->actingAs($message->user)->put('/api/messages/' . $message->id, [
+            'content' => 'updated content',
+        ]);
+
+        // Messageが更新されたかどうか
+        $updatedMessage = Message::find($message->id);
+        $this->assertEquals('updated content', $updatedMessage->content);
+
+        // レスポンスが正しいかどうか
+        $response->assertSuccessful();
+        $this->assertEquals(
+            MessageResource::make($updatedMessage)->toJson(),
+            json_encode($response->json('data'))
+        );
+    }
+
+    public function test_message_can_not_be_updated_if_content_empty()
+    {
+        $message = Message::factory()->create();
+        $response = $this->actingAs($message->user)->put('/api/messages/' . $message->id, [
+            'content' => '',
+        ]);
+
+        // Messageが更新されていないかどうか
+        $updatedMessage = Message::find($message->id);
+        $this->assertNotEquals('updated content', $updatedMessage->content);
+
+        $response->assertJsonValidationErrors(['content' => 'メッセージは、必ず指定してください。']);
+        $response->assertStatus(400);
+    }
+
+    public function test_message_can_not_be_updated_if_content_long()
+    {
+        $message = Message::factory()->create();
+        $response = $this->actingAs($message->user)->put('/api/messages/' . $message->id, [
+            'content' => $this->faker->realTextBetween(),
+        ]);
+
+        // Messageが更新されていないかどうか
+        $updatedMessage = Message::find($message->id);
+        $this->assertNotEquals('updated content', $updatedMessage->content);
+
+        $response->assertJsonValidationErrors(['content' => 'メッセージは、140文字以下にしてください。']);
+        $response->assertStatus(400);
+    }
+
+    public function test_message_can_not_be_updated_if_unauthorized()
+    {
+        $message = Message::factory()->create();
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->put('/api/messages/' . $message->id, [
+            'content' => 'updated content',
+        ]);
+
+        // Messageが更新されていないかどうか
+        $updatedMessage = Message::find($message->id);
+        $this->assertNotEquals('updated content', $updatedMessage->content);
+
+        // レスポンスが正しいかどうか
+        $response->assertStatus(403);
     }
 
     public function test_message_can_be_destroyed()

--- a/tests/Feature/Controllers/Api/MessageControllerTest.php
+++ b/tests/Feature/Controllers/Api/MessageControllerTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature\Controllers\Api;
 
 use App\Http\Resources\MessageResource;
 use App\Models\Message;
+use App\Models\User;
+use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -21,5 +23,32 @@ class MessageControllerTest extends TestCase
             json_encode($response->json('data'))
         );
         $response->assertSuccessful();
+    }
+
+    public function test_message_can_be_destroyed()
+    {
+        $message = Message::factory()->create();
+        $response = $this->actingAs($message->user)->delete('/api/messages/' . $message->id);
+
+        // Messageが削除されているかどうか
+        $deletedMessage = Message::find($message->id);
+        $this->assertEmpty($deletedMessage);
+
+        // レスポンスが正しいかどうか
+        $response->assertSuccessful();
+    }
+
+    public function test_message_cat_not_be_destroyed_if_unauthorized()
+    {
+        $message = Message::factory()->create();
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->delete('/api/messages/' . $message->id);
+
+        // Messageが更新されていないかどうか
+        $deletedMessage = Message::find($message->id);
+        $this->assertNotEmpty($deletedMessage);
+
+        // レスポンスが正しいかどうか
+        $response->assertStatus(403);
     }
 }


### PR DESCRIPTION
## 概要

- メッセージをAPIを使ってCRUDできるようにすること
- 一覧ページでCRUDができるようにすること

## 実装

- [URL一覧のv2](https://www.notion.so/yumemi/URL-58249c1445e341f1aaa1c12a8ebd991e)でmessageに関連するAPIを実装する
- フロントエンドでAPIを呼び出す

## メモ

- [jsファイルで書いた関数がフロントで呼び出せないときの解決策](https://stackoverflow.com/questions/45444537/javascript-function-in-laravel-not-defined/45444639)

## 成果物

https://user-images.githubusercontent.com/56750754/122170550-a22c0e80-ceb9-11eb-94fa-1e1006a4b95e.mov