### PR TITLE
ユーザーページを作成

### DIFF
--- a/app/Http/Controllers/Api/MessageController.php
+++ b/app/Http/Controllers/Api/MessageController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\Message\IndexRequest;
 use App\Http\Requests\Api\Message\StoreRequest;
 use App\Http\Requests\Api\Message\UpdateRequest;
 use App\Http\Resources\MessageResource;
@@ -11,9 +12,12 @@ use Illuminate\Support\Facades\Auth;
 
 class MessageController extends Controller
 {
-    function index()
+    function index(IndexRequest $request)
     {
-        $messages = Message::orderBy('id', 'DESC')->with('user', 'likedUsers')->cursorPaginate(10);
+        $messages = Message::orderBy('id', 'DESC')
+            ->filter($request->validated())
+            ->with('user', 'likedUsers')
+            ->cursorPaginate(10);
 
         return MessageResource::collection($messages);
     }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+
+class UserController extends Controller
+{
+    public function show(User $user)
+    {
+        return view('user.show', compact('user'));
+    }
+}

--- a/app/Http/Requests/Api/Message/IndexRequest.php
+++ b/app/Http/Requests/Api/Message/IndexRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests\Api\Message;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Validation\ValidationException;
+
+class IndexRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'user_id' => 'integer',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator)
+    {
+        $errors = (new ValidationException($validator))->errors();
+        throw new HttpResponseException(response()->json([
+            'message' => 'Failed validation',
+            'errors' => $errors,
+        ], 400));
+    }
+}

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -28,5 +29,13 @@ class Message extends Model
     public function isLiked(User $user): bool
     {
         return $this->likedUsers()->where('user_id', $user->id)->exists();
+    }
+
+    static public function scopeFilter(Builder $query, array $conditions): Builder
+    {
+        foreach ($conditions as $key => $condition) {
+            $query->where($key, $condition);
+        }
+        return $query;
     }
 }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3823,6 +3823,8 @@ __webpack_require__(/*! ./requests/messages/updateMessage */ "./resources/js/req
 
 __webpack_require__(/*! ./requests/messages/destroyMessage */ "./resources/js/requests/messages/destroyMessage.js");
 
+__webpack_require__(/*! ./states/messages */ "./resources/js/states/messages.js");
+
 __webpack_require__(/*! alpinejs */ "./node_modules/alpinejs/dist/alpine.js");
 
 /***/ }),
@@ -4303,6 +4305,285 @@ var updateMessage = /*#__PURE__*/function () {
 }();
 
 window.updateMessage = updateMessage;
+
+/***/ }),
+
+/***/ "./resources/js/states/messages.js":
+/*!*****************************************!*\
+  !*** ./resources/js/states/messages.js ***!
+  \*****************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/regenerator */ "./node_modules/@babel/runtime/regenerator/index.js");
+/* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__);
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }
+
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }
+
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+
+
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+function messages(_ref) {
+  var userId = _ref.userId;
+  return {
+    triggerElement: null,
+    itemsPerPage: 10,
+    nextLink: '/api/messages',
+    observer: null,
+    isObserverPolyfilled: false,
+    items: [],
+    errors: [],
+    newContent: '',
+    init: function init(elementId) {
+      var ctx = this;
+      this.triggerElement = document.querySelector(elementId ? elementId : '#infinite-scroll-trigger');
+
+      if (!('IntersectionObserver' in window) || !('IntersectionObserverEntry' in window) || !('isIntersecting' in window.IntersectionObserverEntry.prototype) || !('intersectionRatio' in window.IntersectionObserverEntry.prototype)) {
+        this.isObserverPolyfilled = true;
+        window.alpineInfiniteScroll = {
+          scrollFunc: function scrollFunc() {
+            var position = ctx.triggerElement.getBoundingClientRect();
+
+            if (position.top < window.innerHeight && position.bottom >= 0) {
+              ctx.getItems();
+            }
+          }
+        };
+        window.addEventListener('scroll', window.alpineInfiniteScroll.scrollFunc);
+      } else {
+        this.observer = new IntersectionObserver(function (entries) {
+          if (entries[0].isIntersecting === true) {
+            ctx.getItems();
+          }
+        }, {
+          threshold: [0]
+        });
+        this.observer.observe(this.triggerElement);
+      }
+    },
+    getItems: function getItems() {
+      var _this = this;
+
+      return _asyncToGenerator( /*#__PURE__*/_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().mark(function _callee() {
+        var link;
+        return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().wrap(function _callee$(_context) {
+          while (1) {
+            switch (_context.prev = _context.next) {
+              case 0:
+                link = userId === undefined ? _this.nextLink : _this.nextLink + '?user_id=' + userId;
+                _context.next = 3;
+                return fetchMessage({
+                  link: link,
+                  onFetchMessage: function onFetchMessage(_ref2) {
+                    var data = _ref2.data,
+                        links = _ref2.links;
+                    _this.nextLink = links.next;
+                    _this.items = _this.items.concat(data.map(function (v) {
+                      return _objectSpread(_objectSpread({}, v), {}, {
+                        tmpContent: v.content,
+                        open: false,
+                        isEditing: false,
+                        errors: []
+                      });
+                    }));
+
+                    if (_this.nextLink === null) {
+                      if (_this.isObserverPolyfilled) {
+                        window.removeEventListener('scroll', window.alpineInfiniteScroll.scrollFunc);
+                      } else {
+                        _this.observer.unobserve(_this.triggerElement);
+                      }
+
+                      _this.triggerElement.parentNode.removeChild(_this.triggerElement);
+                    }
+                  }
+                });
+
+              case 3:
+              case "end":
+                return _context.stop();
+            }
+          }
+        }, _callee);
+      }))();
+    },
+    createItem: function createItem(_ref3) {
+      var _this2 = this;
+
+      return _asyncToGenerator( /*#__PURE__*/_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().mark(function _callee2() {
+        var content;
+        return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().wrap(function _callee2$(_context2) {
+          while (1) {
+            switch (_context2.prev = _context2.next) {
+              case 0:
+                content = _ref3.content;
+                _context2.next = 3;
+                return storeMessage({
+                  content: content,
+                  onStoreMessage: function onStoreMessage(data) {
+                    _this2.items.unshift(_objectSpread(_objectSpread({}, data), {}, {
+                      tmpContent: content,
+                      open: false,
+                      isEditing: false,
+                      errors: []
+                    }));
+
+                    _this2.newContent = '';
+                    _this2.errors = [];
+                  },
+                  onStoreMessageError: function onStoreMessageError(errors) {
+                    for (var k in errors) {
+                      var _this2$errors;
+
+                      (_this2$errors = _this2.errors).push.apply(_this2$errors, _toConsumableArray(errors[k]));
+                    }
+                  }
+                });
+
+              case 3:
+              case "end":
+                return _context2.stop();
+            }
+          }
+        }, _callee2);
+      }))();
+    },
+    cancelEdit: function cancelEdit(item) {
+      item.content = item.tmpContent;
+      item.isEditing = false;
+      item.errors = [];
+    },
+    editItem: function editItem(item) {
+      return _asyncToGenerator( /*#__PURE__*/_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().mark(function _callee3() {
+        return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().wrap(function _callee3$(_context3) {
+          while (1) {
+            switch (_context3.prev = _context3.next) {
+              case 0:
+                _context3.next = 2;
+                return updateMessage({
+                  messageId: item.id,
+                  content: item.content,
+                  onUpdateMessage: function onUpdateMessage(data) {
+                    item.updated_at = data.updated_at;
+                    item.isEdited = true;
+                    item.isEditing = false;
+                    item.tmpContent = item.content;
+                    item.errors = [];
+                  },
+                  onUpdateMessageError: function onUpdateMessageError(errors) {
+                    for (var k in errors) {
+                      var _item$errors;
+
+                      (_item$errors = item.errors).push.apply(_item$errors, _toConsumableArray(errors[k]));
+                    }
+                  }
+                });
+
+              case 2:
+              case "end":
+                return _context3.stop();
+            }
+          }
+        }, _callee3);
+      }))();
+    },
+    deleteItem: function deleteItem(messageId) {
+      var _this3 = this;
+
+      return _asyncToGenerator( /*#__PURE__*/_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().mark(function _callee4() {
+        return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().wrap(function _callee4$(_context4) {
+          while (1) {
+            switch (_context4.prev = _context4.next) {
+              case 0:
+                _context4.next = 2;
+                return destroyMessage({
+                  messageId: messageId,
+                  onDestroyMessage: function onDestroyMessage() {
+                    _this3.items = _this3.items.filter(function (item) {
+                      return item.id !== messageId;
+                    });
+                  }
+                });
+
+              case 2:
+              case "end":
+                return _context4.stop();
+            }
+          }
+        }, _callee4);
+      }))();
+    },
+    likeItem: function likeItem(item) {
+      return _asyncToGenerator( /*#__PURE__*/_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().mark(function _callee5() {
+        return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().wrap(function _callee5$(_context5) {
+          while (1) {
+            switch (_context5.prev = _context5.next) {
+              case 0:
+                _context5.next = 2;
+                return storeLike({
+                  messageId: item.id,
+                  onStoreLike: function onStoreLike() {
+                    item.isLiked = true;
+                    item.likedCount++;
+                  },
+                  onStoreLikeError: function onStoreLikeError() {}
+                });
+
+              case 2:
+              case "end":
+                return _context5.stop();
+            }
+          }
+        }, _callee5);
+      }))();
+    },
+    unlikeItem: function unlikeItem(item) {
+      return _asyncToGenerator( /*#__PURE__*/_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().mark(function _callee6() {
+        return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().wrap(function _callee6$(_context6) {
+          while (1) {
+            switch (_context6.prev = _context6.next) {
+              case 0:
+                _context6.next = 2;
+                return destroyLike({
+                  messageId: item.id,
+                  onDestroyLike: function onDestroyLike() {
+                    item.isLiked = false;
+                    item.likedCount--;
+                  },
+                  onDestroyLikeError: function onDestroyLikeError() {}
+                });
+
+              case 2:
+              case "end":
+                return _context6.stop();
+            }
+          }
+        }, _callee6);
+      }))();
+    }
+  };
+}
+
+window.messages = messages;
 
 /***/ }),
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -7,4 +7,6 @@ require('./requests/messages/storeMessage');
 require('./requests/messages/updateMessage');
 require('./requests/messages/destroyMessage');
 
+require('./states/messages');
+
 require('alpinejs');

--- a/resources/js/states/messages.js
+++ b/resources/js/states/messages.js
@@ -1,0 +1,142 @@
+function messages({ userId }) {
+    return {
+        triggerElement: null,
+        itemsPerPage: 10,
+        nextLink: '/api/messages',
+        observer: null,
+        isObserverPolyfilled: false,
+        items: [],
+        errors: [],
+        newContent: '',
+        init(elementId) {
+            const ctx = this
+            this.triggerElement = document.querySelector(elementId ? elementId : '#infinite-scroll-trigger')
+
+            if (!('IntersectionObserver' in window) ||
+                !('IntersectionObserverEntry' in window) ||
+                !('isIntersecting' in window.IntersectionObserverEntry.prototype) ||
+                !('intersectionRatio' in window.IntersectionObserverEntry.prototype))
+            {
+                this.isObserverPolyfilled = true
+
+                window.alpineInfiniteScroll = {
+                    scrollFunc() {
+                        const position = ctx.triggerElement.getBoundingClientRect()
+
+                        if (position.top < window.innerHeight && position.bottom >= 0) {
+                            ctx.getItems()
+                        }
+                    }
+                }
+
+                window.addEventListener('scroll', window.alpineInfiniteScroll.scrollFunc)
+            } else {
+                this.observer = new IntersectionObserver(function(entries) {
+                    if(entries[0].isIntersecting === true) {
+                        ctx.getItems()
+                    }
+                }, { threshold: [0] })
+                this.observer.observe(this.triggerElement)
+            }
+        },
+        async getItems() {
+            const link = userId === undefined
+                ? this.nextLink
+                : this.nextLink + '?user_id=' + userId;
+            await fetchMessage({
+                link: link,
+                onFetchMessage: ({ data, links }) => {
+                    this.nextLink = links.next;
+                    this.items = this.items.concat(data.map(v => ({
+                        ...v,
+                        tmpContent: v.content,
+                        open: false,
+                        isEditing: false,
+                        errors: [],
+                    })));
+                    if (this.nextLink === null) {
+                        if (this.isObserverPolyfilled) {
+                            window.removeEventListener('scroll', window.alpineInfiniteScroll.scrollFunc)
+                        } else {
+                            this.observer.unobserve(this.triggerElement)
+                        }
+                        this.triggerElement.parentNode.removeChild(this.triggerElement)
+                    }
+                },
+            });
+        },
+        async createItem({ content }) {
+            await storeMessage({
+                content,
+                onStoreMessage: (data) => {
+                    this.items.unshift({
+                        ...data,
+                        tmpContent: content,
+                        open: false,
+                        isEditing: false,
+                        errors: [],
+                    });
+                    this.newContent = '';
+                    this.errors = [];
+                },
+                onStoreMessageError: (errors) => {
+                    for (let k in errors) {
+                        this.errors.push(...errors[k]);
+                    }
+                },
+            });
+        },
+        cancelEdit(item) {
+            item.content = item.tmpContent;
+            item.isEditing = false;
+            item.errors = [];
+        },
+        async editItem(item) {
+            await updateMessage({
+                messageId: item.id,
+                content: item.content,
+                onUpdateMessage: (data) => {
+                    item.updated_at = data.updated_at;
+                    item.isEdited = true;
+                    item.isEditing = false;
+                    item.tmpContent = item.content;
+                    item.errors = [];
+                },
+                onUpdateMessageError: (errors) => {
+                    for (let k in errors) {
+                        item.errors.push(...errors[k]);
+                    }
+                },
+            })
+        },
+        async deleteItem(messageId) {
+            await destroyMessage({
+                messageId,
+                onDestroyMessage: () => {
+                    this.items = this.items.filter(item => item.id !== messageId);
+                },
+            });
+        },
+        async likeItem(item) {
+            await storeLike({
+                messageId: item.id,
+                onStoreLike: () => {
+                    item.isLiked = true;
+                    item.likedCount++;
+                },
+                onStoreLikeError: () => {},
+            });
+        },
+        async unlikeItem(item) {
+            await destroyLike({
+                messageId: item.id,
+                onDestroyLike: () => {
+                    item.isLiked = false;
+                    item.likedCount--;
+                },
+                onDestroyLikeError: () => {},
+            });
+        },
+    };
+}
+window.messages = messages;

--- a/resources/views/components/message-cards.blade.php
+++ b/resources/views/components/message-cards.blade.php
@@ -10,7 +10,7 @@
                 </template>
             </div>
             <div class="text-gray-dark flex items-center">
-                <p  x-text="`${item.user.nickname}@${item.user.id}`"></p>
+                <a class="block" x-bind:href="`/users/${item.user.id}`" x-text="`${item.user.nickname}@${item.user.id}`"></a>
                 <template x-if="user?.id === item.user.id">
                     <div class="relative" @click.away="item.open = false" @close.stop="item.open = false">
                         <div @click="item.open = !item.open">

--- a/resources/views/user/show.blade.php
+++ b/resources/views/user/show.blade.php
@@ -1,14 +1,8 @@
 <x-app-layout>
     <div class="relative min-h-screen bg-gray-100 dark:bg-gray-900 sm:pt-24 pb-10">
         <div class="max-w-6xl mx-auto sm:px-6 lg:px-8">
-            <div x-data="messages({})" x-init="init()">
-                <template x-if="user !== null">
-                    <div>
-                        <x-message-create-form />
-                        <hr>
-                    </div>
-                </template>
-
+            <div x-data="{ ...messages({ userId }), nickname: userNickname }" x-init="init()">
+                <h3 class="text-2xl" x-text="nickname"></h3>
                 <x-message-cards />
 
                 <div class="bg-white h-64 flex text-pink-600 items-center justify-center mx-3 my-5 rounded-lg shadow-md" id="infinite-scroll-trigger">
@@ -24,5 +18,7 @@
 </x-app-layout>
 
 <script>
-    const user = @json(Auth::user());
+    const user = @json(Auth::user()); // ログインしているユーザー
+    const userId = @json($user->id); // 現在表示されている画面のユーザーID
+    const userNickname = @json($user->nickname); // 現在表示されている画面のユーザーのニックネーム
 </script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\DefaultController;
 use App\Http\Controllers\MessageController;
+use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -29,5 +30,8 @@ Route::post('/messages/{message}', [MessageController::class, 'update'])
 Route::delete('/messages/{message}', [MessageController::class, 'destroy'])
     ->middleware('can:destroy,message')
     ->name('messages.destroy');
+
+Route::get('/users/{user}', [UserController::class, 'show'])
+    ->name('users.show');
 
 require __DIR__ . '/auth.php';

--- a/tests/Feature/Controllers/UserControllerTest.php
+++ b/tests/Feature/Controllers/UserControllerTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Feature\Controllers;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_show_user_screen_can_be_rendered()
+    {
+        $user = User::factory()->create();
+        $response = $this->get('/users/' . $user->id);
+
+        $response->assertViewHas('user', $user);
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## 概要

ユーザーが投稿したメッセージの一覧が見れるページを作成する

## 実装

- `/user/{user}`を作成
- `/api/messages?user_id=1`などでフィルタリングできるようにする
- フロントエンドの作成
- フロントエンドで状態管理のロジックを切り出し

## 成果物

https://user-images.githubusercontent.com/56750754/122499231-7e88d580-d02b-11eb-9d53-34d1cce7572a.mov
